### PR TITLE
update sitemap lastmod

### DIFF
--- a/src/main/java/run/halo/sitemap/SitemapGeneratorOptions.java
+++ b/src/main/java/run/halo/sitemap/SitemapGeneratorOptions.java
@@ -37,7 +37,7 @@ public class SitemapGeneratorOptions {
     private boolean allowMultipleSitemaps = true;
 
     @Builder.Default
-    private DateTimeFormatter dateTimeFormatter = W3cDatetimeFormat.MILLISECOND_FORMATTER;
+    private DateTimeFormatter dateTimeFormatter = W3cDatetimeFormat.SECOND_FORMATTER;
 
     /**
      * Split large sitemap into multiple files by specifying sitemap size. Default 5000.

--- a/src/main/java/run/halo/sitemap/W3cDatetimeFormat.java
+++ b/src/main/java/run/halo/sitemap/W3cDatetimeFormat.java
@@ -60,13 +60,13 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public final class W3cDatetimeFormat {
     public static final DateTimeFormatter MILLISECOND_FORMATTER =
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
 
     public static final DateTimeFormatter SECOND_FORMATTER =
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ");
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX");
 
     public static final DateTimeFormatter MINUTE_FORMATTER =
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mmZ");
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mmXXX");
 
     public static String format(Instant instant, DateTimeFormatter formatter) {
         return instant.atZone(ZoneId.systemDefault())
@@ -74,6 +74,6 @@ public final class W3cDatetimeFormat {
     }
 
     public static String format(Instant instant) {
-        return format(instant, MILLISECOND_FORMATTER);
+        return format(instant, SECOND_FORMATTER);
     }
 }


### PR DESCRIPTION
使用Google提交sitemap.xml，显示日期格式无效
参考 <https://sitemaps.org> 日期格式示例，需要去掉毫秒，并且时区格式为08:00

![Snipaste_2022-12-10_16-57-43](https://user-images.githubusercontent.com/57121007/206849070-114476b3-b120-476c-a135-ddf520a6c860.png)
![Snipaste_2022-12-10_17-32-45](https://user-images.githubusercontent.com/57121007/206849077-51d98e6a-78dc-49e3-854a-ac67324c0e30.png)
![Snipaste_2022-12-10_17-41-41](https://user-images.githubusercontent.com/57121007/206849079-d7ec13d2-d7a7-4ac3-a69d-e11d2d37e3cb.png)


```release-note
None
```