### PR TITLE
refactor: fix reactive anti-pattern and cache key in CachedSitemapGetter

### DIFF
--- a/src/main/java/run/halo/sitemap/CachedSitemapGetter.java
+++ b/src/main/java/run/halo/sitemap/CachedSitemapGetter.java
@@ -1,39 +1,33 @@
 package run.halo.sitemap;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.AsyncCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import java.time.Duration;
 import lombok.AllArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 @Component
 @AllArgsConstructor
 public class CachedSitemapGetter {
 
-    private final Cache<SitemapGeneratorOptions, String> cache = CacheBuilder.newBuilder()
-        .concurrencyLevel(Runtime.getRuntime().availableProcessors())
-        .initialCapacity(8)
-        .maximumSize(8)
+    private final AsyncCache<String, String> cache = Caffeine.newBuilder()
         .expireAfterWrite(Duration.ofSeconds(30))
-        .build();
+        .maximumSize(8)
+        .buildAsync();
 
     private final DefaultSitemapEntryLister lister;
 
     public Mono<String> get(SitemapGeneratorOptions options) {
-        return Mono.fromCallable(() -> cache.get(options, () -> lister.list(options)
-                .collectList()
-                .map(entries -> {
-                    String xml = new SitemapBuilder()
-                        .buildSitemapXml(entries);
-                    cache.put(options, xml);
-                    return xml;
-                })
-                .defaultIfEmpty(StringUtils.EMPTY)
-                .block()
-            ))
-            .subscribeOn(Schedulers.boundedElastic());
+        String key = options.getSiteUrl().toString();
+        return Mono.fromFuture(() ->
+            cache.get(key, (k, executor) ->
+                lister.list(options)
+                    .collectList()
+                    .map(entries -> new SitemapBuilder().buildSitemapXml(entries))
+                    .defaultIfEmpty("")
+                    .toFuture()
+            )
+        );
     }
 }

--- a/src/test/java/run/halo/sitemap/CachedSitemapGetterTest.java
+++ b/src/test/java/run/halo/sitemap/CachedSitemapGetterTest.java
@@ -1,10 +1,12 @@
 package run.halo.sitemap;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
@@ -22,33 +24,33 @@ public class CachedSitemapGetterTest {
     @Mock
     private DefaultSitemapEntryLister lister;
     private CachedSitemapGetter getter;
+    private SitemapGeneratorOptions options;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws MalformedURLException {
         when(lister.list(any())).thenReturn(
             Flux.just(SitemapEntry.builder().loc("http://localhost:8090/about").build()));
         getter = new CachedSitemapGetter(lister);
+        options = SitemapGeneratorOptions.builder()
+            .siteUrl(new URL("http://localhost:8090"))
+            .build();
     }
 
     @Test
     void get() throws InterruptedException, ExecutionException {
-        var options = mock(SitemapGeneratorOptions.class);
-
         getter.get(options).block();
-        verify(lister).list(options);
+        verify(lister).list(any());
 
         var executorService = Executors.newCachedThreadPool();
 
         List<? extends Future<?>> futures = IntStream.range(0, 10)
-            .mapToObj(i -> executorService.submit(() -> {
-                getter.get(options).block();
-            }))
+            .mapToObj(i -> executorService.submit(() -> getter.get(options).block()))
             .toList();
 
         for (Future<?> future : futures) {
             future.get();
         }
 
-        verify(lister).list(options);
+        verify(lister, times(1)).list(any());
     }
 }


### PR DESCRIPTION
## Summary

Three issues in the previous `CachedSitemapGetter` implementation:

1. **Reactive anti-pattern**: `Guava Cache.get(key, Callable)` was used with `.block()` inside the callable. This is a reactive anti-pattern — even on `Schedulers.boundedElastic()`, nesting `.block()` inside a Guava cache loader risks deadlock under concurrent load.
2. **DNS-triggering cache key**: `SitemapGeneratorOptions` (which contains `java.net.URL`) was used as the cache key. `URL.equals()` and `URL.hashCode()` perform DNS resolution on every cache lookup, which is a well-known Java gotcha.
3. **Redundant `cache.put()`**: Guava's `cache.get(key, callable)` automatically stores the callable result — the explicit `cache.put()` call afterward was redundant.

## Changes

- Replace Guava `Cache` with Caffeine `AsyncCache<String, String>`
- Use `siteUrl.toString()` as the cache key (plain `String`, no DNS lookup)
- The loader returns a `CompletableFuture` directly from the reactive pipeline (`.toFuture()`), wrapped in `Mono.fromFuture()` — no `.block()` anywhere
- Caffeine automatically deduplicates concurrent loads for the same key

## Test plan

- [ ] `CachedSitemapGetterTest.get()` — lister is called exactly once even with 10 concurrent requests hitting the same key
- [ ] Verify no blocking calls appear on the reactive event loop thread

Made with [Cursor](https://cursor.com)

```release-note
None
```