### PR TITLE
chore: minor code quality improvements

### DIFF
--- a/src/main/java/run/halo/sitemap/SitemapPluginConfig.java
+++ b/src/main/java/run/halo/sitemap/SitemapPluginConfig.java
@@ -3,6 +3,7 @@ package run.halo.sitemap;
 import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
 import static org.springframework.web.reactive.function.server.RequestPredicates.accept;
 
+import java.nio.charset.StandardCharsets;
 import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.annotation.Bean;
@@ -33,9 +34,12 @@ public class SitemapPluginConfig {
                 var options = SitemapGeneratorOptions.builder()
                     .siteUrl(url)
                     .build();
+                var xmlMediaType = new MediaType(MediaType.TEXT_XML, StandardCharsets.UTF_8);
                 return cachedSitemapGetter.get(options)
+                    .filter(sitemap -> !sitemap.isBlank())
                     .flatMap(sitemap -> ServerResponse.ok()
-                        .contentType(MediaType.TEXT_XML).bodyValue(sitemap));
+                        .contentType(xmlMediaType).bodyValue(sitemap))
+                    .switchIfEmpty(ServerResponse.noContent().build());
             }
         );
     }

--- a/src/main/java/run/halo/sitemap/UrlUtils.java
+++ b/src/main/java/run/halo/sitemap/UrlUtils.java
@@ -20,11 +20,11 @@ public final class UrlUtils {
      */
     public static String escapeSitemapUrl(String url) {
         Assert.notNull(url, "The url must not be null");
-        return url.replaceAll("&", "&amp;")
-            .replaceAll("'", "&apos;")
-            .replaceAll("\"", "&quot;")
-            .replaceAll(">", "&gt;")
-            .replaceAll("<", "&lt;");
+        return url.replace("&", "&amp;")
+            .replace("'", "&apos;")
+            .replace("\"", "&quot;")
+            .replace(">", "&gt;")
+            .replace("<", "&lt;");
     }
 
     public static URI toURI(String s) {


### PR DESCRIPTION
## Summary

Three small independent improvements:

- **`UrlUtils.escapeSitemapUrl()`**: Replace all five `replaceAll()` calls with `replace()`. `replaceAll()` compiles a regex pattern on every invocation even for literal strings; `replace()` does a plain string search and is both faster and clearer in intent.

- **`SitemapPluginConfig` — Content-Type charset**: The sitemap response Content-Type was `text/xml` with no charset declaration. Per RFC 7303, XML served as `text/*` should declare the encoding explicitly. Changed to `text/xml;charset=UTF-8` so clients do not need to guess or rely on the XML declaration inside the document.

- **`SitemapPluginConfig` — empty sitemap handling**: When the lister returns an empty result, the previous code would return HTTP 200 with a blank body. Added `.filter(!blank)` + `.switchIfEmpty(noContent())` so an empty sitemap returns HTTP 204 instead, which is more semantically correct and avoids clients trying to parse an empty body as XML.

## Test plan

- [ ] Verify `/sitemap.xml` response includes `Content-Type: text/xml;charset=UTF-8` header
- [ ] On a fresh site with no content, verify `/sitemap.xml` returns 204 instead of 200 with empty body
- [ ] Confirm existing sitemap generation is unaffected

Made with [Cursor](https://cursor.com)

```release-note
None
```